### PR TITLE
Add PHP example with Docker and Terraform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM php:8-apache
+COPY src/ /var/www/html/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# PHP Upscalling
+
+This project provides a simple PHP application with Docker and Terraform configurations.
+
+## Docker Setup
+
+1. Build the image:
+   ```bash
+   docker build -t php_app .
+   ```
+2. Run the container:
+   ```bash
+   docker run -p 8080:80 php_app
+   ```
+   The app will be available at [http://localhost:8080](http://localhost:8080).
+
+## Terraform Setup
+
+Terraform configuration in `terraform/` directory provisions a container using the Docker provider.
+
+1. Initialize Terraform:
+   ```bash
+   terraform init
+   ```
+2. Apply the configuration:
+   ```bash
+   terraform apply
+   ```
+   This starts a container exposing the app on port 8080.

--- a/src/index.php
+++ b/src/index.php
@@ -1,0 +1,5 @@
+<?php
+
+echo "Hello World";
+
+?>

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 2.23"
+    }
+  }
+}
+
+provider "docker" {}
+
+resource "docker_image" "php" {
+  name = "php:8-apache"
+}
+
+resource "docker_container" "php_app" {
+  name  = "php_app"
+  image = docker_image.php.latest
+  ports {
+    internal = 80
+    external = 8080
+  }
+}


### PR DESCRIPTION
## Summary
- create PHP script under `src`
- add Dockerfile for PHP 8 Apache image
- add basic Terraform config to launch container
- document Docker and Terraform usage

## Testing
- `terraform init -backend=false` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851797a30d4832ab008992fcf1eb869