### PR TITLE
Fix undefined variable in deploy script

### DIFF
--- a/src/deploy.php
+++ b/src/deploy.php
@@ -30,6 +30,6 @@ $cmd = "cd $tmpdir && terraform init -input=false && terraform apply -auto-appro
 $output = shell_exec($cmd);
 
 // 🖨️ Affiche le résultat à l'écran
-echo "<h2>Résultat du déploiement pour $os :</h2>";
+echo "<h2>Résultat du déploiement pour $os_safe :</h2>";
 echo "<pre>$output</pre>";
 ?>


### PR DESCRIPTION
## Summary
- output sanitized OS variable in deployment status

## Testing
- `php -l src/deploy.php` *(fails: command not found)*
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541dbda328832a9045d9cd80fdb331