### PR TITLE
Switch to host_config binds for Docker container

### DIFF
--- a/terraform/terraform_php/main.tf
+++ b/terraform/terraform_php/main.tf
@@ -29,15 +29,12 @@ resource "docker_container" "php_app" {
     external = 8181
   }
 
-  # Remplacez host_config par des blocs volumes
-  volumes {
-    host_path      = abspath("${path.module}/..")
-    container_path = "/var/www/terraform"
-  }
-
-  volumes {
-    host_path      = "/var/run/docker.sock"
-    container_path = "/var/run/docker.sock"
+  # Utilise host_config pour monter les volumes necessaires
+  host_config {
+    binds = [
+      "${abspath("${path.module}/..")}:\/var\/www\/terraform",
+      "/var/run/docker.sock:/var/run/docker.sock"
+    ]
   }
 }
 


### PR DESCRIPTION
## Summary
- configure Docker provider container resource to use `host_config` binds instead of `volumes`

## Testing
- `terraform -chdir=terraform/terraform_php validate` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68541dbedc74832a89c1614b0e264282