### PR TITLE
Update Docker and Terraform configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,8 @@ RUN apt-get update && \
     mv terraform /usr/local/bin/ && \
     chmod +x /usr/local/bin/terraform && \
     rm terraform_1.8.2_linux_amd64.zip
+
+# Ajoute l'utilisateur www-data au groupe docker (GID a adapter selon l'hote)
+RUN groupadd -g 999 docker && usermod -aG docker www-data
     
 COPY src/ /var/www/html/

--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ This project provides a simple PHP application with Docker and Terraform configu
    ```bash
    docker build -t php_app .
    ```
-2. Run the container:
+2. Run the container (mount the Docker socket so Terraform can manage Docker):
    ```bash
-   docker run -p 8181:80 php_app
+   docker run -p 8181:80 \
+     -v /var/run/docker.sock:/var/run/docker.sock \
+     php_app
    ```
    The app will be available at [http://localhost:8181](http://localhost:8181).
+
+The container adds `www-data` to the `docker` group (GID `999` by default).
+If your host uses a different group ID for Docker, update the Dockerfile accordingly.
 
 ## Terraform Setup
 

--- a/terraform/terraform_php/main.tf
+++ b/terraform/terraform_php/main.tf
@@ -29,12 +29,17 @@ resource "docker_container" "php_app" {
     external = 8181
   }
 
-  # Utilise host_config pour monter les volumes necessaires
-  host_config {
-    binds = [
-      "${abspath("${path.module}/..")}:\/var\/www\/terraform",
-      "/var/run/docker.sock:/var/run/docker.sock"
-    ]
+  # Utilise des mounts pour partager les volumes necessaires
+  mounts {
+    target = "/var/www/terraform"
+    source = abspath("${path.module}/..")
+    type   = "bind"
+  }
+
+  mounts {
+    target = "/var/run/docker.sock"
+    source = "/var/run/docker.sock"
+    type   = "bind"
   }
 }
 


### PR DESCRIPTION
## Summary
- give `www-data` access to Docker socket via docker group
- use mount blocks instead of host_config in Terraform
- update Docker usage instructions

## Testing
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551d545724832aa9bf54008ab69323